### PR TITLE
Add colorized output with optional disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = cc
 CFLAGS = -Wall -Wextra -std=c99 -Iinclude
-OBJS = build/main.o build/list.o
-DEPS = include/list.h
+OBJS = build/main.o build/list.o build/color.o
+DEPS = include/list.h include/color.h
 
 all: build/vls
 
@@ -13,6 +13,9 @@ build/main.o: src/main.c $(DEPS) | build
 
 build/list.o: src/list.c $(DEPS) | build
 	$(CC) $(CFLAGS) -c src/list.c -o build/list.o
+
+build/color.o: src/color.c include/color.h | build
+	$(CC) $(CFLAGS) -c src/color.c -o build/color.o
 
 build:
 	mkdir -p build

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ls replacement utility for UNIX
 
 vls is a minimal tool intended as a replacement for the standard `ls` command.
 
+File names are colorized based on type (directories, links and executables).
+Pass `--no-color` to disable colored output.
+
 ## Building
 Run `make` to compile the project. The resulting executable will be placed in `build/vls`.
 

--- a/include/color.h
+++ b/include/color.h
@@ -1,0 +1,9 @@
+#ifndef COLOR_H
+#define COLOR_H
+
+const char *color_reset(void);
+const char *color_dir(void);
+const char *color_link(void);
+const char *color_exec(void);
+
+#endif // COLOR_H

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path);
+void list_directory(const char *path, int use_color);
 
 #endif // LIST_H

--- a/src/color.c
+++ b/src/color.c
@@ -1,0 +1,6 @@
+#include "color.h"
+
+const char *color_reset(void) { return "\x1b[0m"; }
+const char *color_dir(void)   { return "\x1b[1;34m"; }
+const char *color_link(void)  { return "\x1b[1;36m"; }
+const char *color_exec(void)  { return "\x1b[1;32m"; }

--- a/src/list.c
+++ b/src/list.c
@@ -1,8 +1,15 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <dirent.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <limits.h>
+#include <unistd.h>
+#include <linux/limits.h>
 #include "list.h"
+#include "color.h"
 
-void list_directory(const char *path) {
+void list_directory(const char *path, int use_color) {
     DIR *dir = opendir(path);
     if (!dir) {
         perror("opendir");
@@ -10,8 +17,27 @@ void list_directory(const char *path) {
     }
 
     struct dirent *entry;
+    char fullpath[PATH_MAX];
     while ((entry = readdir(dir)) != NULL) {
-        printf("%s\n", entry->d_name);
+        snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entry->d_name);
+        struct stat st;
+        if (lstat(fullpath, &st) == -1) {
+            perror("stat");
+            continue;
+        }
+
+        const char *prefix = "";
+        const char *suffix = "";
+        if (use_color) {
+            if (S_ISDIR(st.st_mode))
+                prefix = color_dir();
+            else if (S_ISLNK(st.st_mode))
+                prefix = color_link();
+            else if (st.st_mode & S_IXUSR)
+                prefix = color_exec();
+            suffix = color_reset();
+        }
+        printf("%s%s%s\n", prefix, entry->d_name, suffix);
     }
 
     closedir(dir);

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,22 @@
 #include <stdio.h>
+#include <string.h>
 #include "list.h"
 
 #define VLS_VERSION "0.1"
 
-int main(void) {
+int main(int argc, char *argv[]) {
+    int use_color = 1;
+    const char *path = ".";
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--no-color") == 0) {
+            use_color = 0;
+        } else {
+            path = argv[i];
+        }
+    }
+
     printf("vls %s\n", VLS_VERSION);
-    list_directory(".");
+    list_directory(path, use_color);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- detect file types via `stat` for listing
- wrap filenames with ANSI color sequences
- add `--no-color` option to disable coloring
- document color feature in README

## Testing
- `make clean`
- `make`
- `./build/vls | head`
- `./build/vls --no-color | head`


------
https://chatgpt.com/codex/tasks/task_e_6852e35b092483249dbc60549eeef23c