### PR TITLE
Add flag parsing and update listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = cc
 CFLAGS = -Wall -Wextra -std=c99 -Iinclude
-OBJS = build/main.o build/list.o build/color.o
-DEPS = include/list.h include/color.h
+OBJS = build/main.o build/list.o build/color.o build/args.o
+DEPS = include/list.h include/color.h include/args.h
 
 all: build/vls
 
@@ -17,10 +17,19 @@ build/list.o: src/list.c $(DEPS) | build
 build/color.o: src/color.c include/color.h | build
 	$(CC) $(CFLAGS) -c src/color.c -o build/color.o
 
+build/args.o: src/args.c include/args.h | build
+	$(CC) $(CFLAGS) -c src/args.c -o build/args.o
+
 build:
 	mkdir -p build
+
+test: build/vls
+	./build/vls -a > /dev/null
+	./build/vls -l > /dev/null
+	./build/vls --no-color > /dev/null
+	@echo "Tests completed"
 
 clean:
 	rm -f build/vls build/*.o
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/include/args.h
+++ b/include/args.h
@@ -1,0 +1,13 @@
+#ifndef ARGS_H
+#define ARGS_H
+
+typedef struct {
+    const char *path;
+    int use_color;
+    int show_hidden;
+    int long_format;
+} Args;
+
+void parse_args(int argc, char *argv[], Args *args);
+
+#endif // ARGS_H

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color);
+void list_directory(const char *path, int use_color, int show_hidden, int long_format);
 
 #endif // LIST_H

--- a/src/args.c
+++ b/src/args.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include "args.h"
+
+void parse_args(int argc, char *argv[], Args *args) {
+    args->use_color = 1;
+    args->show_hidden = 0;
+    args->long_format = 0;
+    args->path = ".";
+
+    static struct option long_options[] = {
+        {"no-color", no_argument, 0, 'C'},
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    int opt;
+    while ((opt = getopt_long(argc, argv, "alCh", long_options, NULL)) != -1) {
+        switch (opt) {
+        case 'a':
+            args->show_hidden = 1;
+            break;
+        case 'l':
+            args->long_format = 1;
+            break;
+        case 'C':
+            args->use_color = 0;
+            break;
+        case 'h':
+            printf("Usage: %s [-a] [-l] [--no-color] [path]\n", argv[0]);
+            exit(0);
+            break;
+        default:
+            fprintf(stderr, "Usage: %s [-a] [-l] [--no-color] [path]\n", argv[0]);
+            exit(1);
+        }
+    }
+
+    if (optind < argc)
+        args->path = argv[optind];
+}

--- a/src/list.c
+++ b/src/list.c
@@ -9,7 +9,7 @@
 #include "list.h"
 #include "color.h"
 
-void list_directory(const char *path, int use_color) {
+void list_directory(const char *path, int use_color, int show_hidden, int long_format) {
     DIR *dir = opendir(path);
     if (!dir) {
         perror("opendir");
@@ -19,6 +19,9 @@ void list_directory(const char *path, int use_color) {
     struct dirent *entry;
     char fullpath[PATH_MAX];
     while ((entry = readdir(dir)) != NULL) {
+        if (!show_hidden && entry->d_name[0] == '.')
+            continue;
+
         snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entry->d_name);
         struct stat st;
         if (lstat(fullpath, &st) == -1) {
@@ -37,7 +40,11 @@ void list_directory(const char *path, int use_color) {
                 prefix = color_exec();
             suffix = color_reset();
         }
-        printf("%s%s%s\n", prefix, entry->d_name, suffix);
+
+        if (long_format)
+            printf("%s%10lld %s%s\n", prefix, (long long)st.st_size, entry->d_name, suffix);
+        else
+            printf("%s%s%s\n", prefix, entry->d_name, suffix);
     }
 
     closedir(dir);

--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,14 @@
 #include <stdio.h>
-#include <string.h>
 #include "list.h"
+#include "args.h"
 
 #define VLS_VERSION "0.1"
 
 int main(int argc, char *argv[]) {
-    int use_color = 1;
-    const char *path = ".";
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "--no-color") == 0) {
-            use_color = 0;
-        } else {
-            path = argv[i];
-        }
-    }
+    Args args;
+    parse_args(argc, argv, &args);
 
     printf("vls %s\n", VLS_VERSION);
-    list_directory(path, use_color);
+    list_directory(args.path, args.use_color, args.show_hidden, args.long_format);
     return 0;
 }
-


### PR DESCRIPTION
## Summary
- parse command line options with getopt
- add options for showing hidden files and long listing format
- update list implementation to honor parsed flags
- update main to use the new args
- extend Makefile with build/test rules

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852e6522f5483248bdfeca818bafc32