### PR TITLE
Add platform detection and cross-platform docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
-CC = cc
-CFLAGS = -Wall -Wextra -std=c99 -Iinclude
+CC ?= cc
+CFLAGS ?= -Wall -Wextra -std=c99 -Iinclude
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    PLATFORM_CFLAGS = -D_DARWIN_C_SOURCE
+else ifeq ($(UNAME_S),NetBSD)
+    PLATFORM_CFLAGS = -D_NETBSD_SOURCE
+else ifeq ($(UNAME_S),Linux)
+    PLATFORM_CFLAGS = -D_GNU_SOURCE
+endif
+CFLAGS += $(PLATFORM_CFLAGS)
 OBJS = build/main.o build/list.o build/color.o build/args.o
 DEPS = include/list.h include/color.h include/args.h
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,45 @@ vls is a minimal tool intended as a replacement for the standard `ls` command.
 File names are colorized based on type (directories, links and executables).
 Pass `--no-color` to disable colored output.
 
-## Building
-Run `make` to compile the project. The resulting executable will be placed in `build/vls`.
+## Building and Testing
+The build system uses a simple Makefile which detects the host OS with
+`uname` and appends a few platform specific flags. In most cases you only
+need to run `make`:
+
+```sh
+make
+```
+
+### Linux
+On Linux the Makefile defines `-D_GNU_SOURCE` automatically. Simply run the
+commands above. To run the basic tests:
+
+```sh
+make test
+```
+
+### macOS
+The Makefile adds `-D_DARWIN_C_SOURCE` on macOS. Use the same build and test
+commands:
+
+```sh
+make
+make test
+```
+
+### NetBSD
+On NetBSD the flag `-D_NETBSD_SOURCE` is applied. Invoke make normally:
+
+```sh
+make
+make test
+```
+
+You can also provide your own `CFLAGS` to override or extend the defaults:
+
+```sh
+make CFLAGS="-O2"
+```
+
+The resulting executable is placed in `build/vls`.
 

--- a/src/list.c
+++ b/src/list.c
@@ -5,7 +5,15 @@
 #include <string.h>
 #include <limits.h>
 #include <unistd.h>
-#include <linux/limits.h>
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
+# include <sys/param.h>
+# ifndef PATH_MAX
+#  define PATH_MAX MAXPATHLEN
+# endif
+#endif
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
 #include "list.h"
 #include "color.h"
 


### PR DESCRIPTION
## Summary
- handle PATH_MAX without linux/limits.h
- auto-set build flags based on uname
- document build steps for Linux, macOS and NetBSD

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852e7b4f6cc8324b5421865e7eadedc