### PR TITLE
Add time sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ vls is a minimal tool intended as a replacement for the standard `ls` command.
 File names are colorized based on type (directories, links and executables).
 Pass `--no-color` to disable colored output.
 Use `-r` to display entries in reverse alphabetical order.
+Use `-t` to sort entries by modification time.
 
 ## Building and Testing
 The build system uses a simple Makefile which detects the host OS with

--- a/include/args.h
+++ b/include/args.h
@@ -6,6 +6,7 @@ typedef struct {
     int use_color;
     int show_hidden;
     int long_format;
+    int sort_time;
     int reverse;
 } Args;
 

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int long_format, int reverse);
+void list_directory(const char *path, int use_color, int show_hidden, int long_format, int sort_time, int reverse);
 
 #endif // LIST_H

--- a/src/args.c
+++ b/src/args.c
@@ -7,6 +7,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->use_color = 1;
     args->show_hidden = 0;
     args->long_format = 0;
+    args->sort_time = 0;
     args->reverse = 0;
     args->path = ".";
 
@@ -17,13 +18,16 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "alrCh", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "altrCh", long_options, NULL)) != -1) {
         switch (opt) {
         case 'a':
             args->show_hidden = 1;
             break;
         case 'l':
             args->long_format = 1;
+            break;
+        case 't':
+            args->sort_time = 1;
             break;
         case 'r':
             args->reverse = 1;
@@ -32,11 +36,11 @@ void parse_args(int argc, char *argv[], Args *args) {
             args->use_color = 0;
             break;
         case 'h':
-            printf("Usage: %s [-a] [-l] [-r] [--no-color] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-l] [-t] [-r] [--no-color] [path]\n", argv[0]);
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-l] [-r] [--no-color] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-l] [-t] [-r] [--no-color] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,6 @@ int main(int argc, char *argv[]) {
     parse_args(argc, argv, &args);
 
     printf("vls %s\n", VLS_VERSION);
-    list_directory(args.path, args.use_color, args.show_hidden, args.long_format, args.reverse);
+    list_directory(args.path, args.use_color, args.show_hidden, args.long_format, args.sort_time, args.reverse);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a `sort_time` flag in the argument structure
- parse `-t` in the argument parser
- store stat info for each entry and sort by modification time when requested
- mention new flag in the README

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852ea15e44883248a9cd1bd3466d858