### PR TITLE
Add -L option to follow symbolic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Use `-i` to display inode numbers.
 Use `-R` to recursively list subdirectories (symbolic links are not followed).
 Use `-F` to append indicators to entries: `/` for directories, `*` for executables and `@` for symbolic links.
 Use `-h` to display file sizes in human readable units when combined with `-l`.
+Use `-L` to follow symbolic links when retrieving file details (the default is to display information about the links themselves).
 
 Example of long format output:
 

--- a/include/args.h
+++ b/include/args.h
@@ -11,6 +11,7 @@ typedef struct {
     int sort_size;
     int reverse;
     int recursive;
+    int follow_links;
     int human_readable;
     int classify;
 } Args;

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable);
+void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links);
 
 #endif // LIST_H

--- a/src/args.c
+++ b/src/args.c
@@ -13,6 +13,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->reverse = 0;
     args->recursive = 0;
     args->classify = 0;
+    args->follow_links = 0;
     args->human_readable = 0;
     args->path = ".";
 
@@ -23,7 +24,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "ialtrSChRFh", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "ialtrSChRFhL", long_options, NULL)) != -1) {
         switch (opt) {
         case 'a':
             args->show_hidden = 1;
@@ -49,6 +50,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'F':
             args->classify = 1;
             break;
+        case 'L':
+            args->follow_links = 1;
+            break;
         case 'h':
             args->human_readable = 1;
             break;
@@ -56,11 +60,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             args->use_color = 0;
             break;
         case 1:
-            printf("Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
+            printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -71,7 +71,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable) {
+void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links) {
     DIR *dir = opendir(path);
     if (!dir) {
         perror("opendir");
@@ -109,7 +109,8 @@ void list_directory(const char *path, int use_color, int show_hidden, int long_f
         }
         char fullpath[PATH_MAX];
         snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entries[count].name);
-        if (lstat(fullpath, &entries[count].st) == -1) {
+        int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
+        if (stat_fn(fullpath, &entries[count].st) == -1) {
             perror("stat");
             free(entries[count].name);
             continue;
@@ -255,7 +256,7 @@ void list_directory(const char *path, int use_color, int show_hidden, int long_f
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, use_color, show_hidden, long_format, show_inode, sort_time, sort_size, reverse, recursive, classify, human_readable);
+            list_directory(fullpath, use_color, show_hidden, long_format, show_inode, sort_time, sort_size, reverse, recursive, classify, human_readable, follow_links);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,6 @@ int main(int argc, char *argv[]) {
     parse_args(argc, argv, &args);
 
     printf("vls %s\n", VLS_VERSION);
-    list_directory(args.path, args.use_color, args.show_hidden, args.long_format, args.show_inode, args.sort_time, args.sort_size, args.reverse, args.recursive, args.classify, args.human_readable);
+    list_directory(args.path, args.use_color, args.show_hidden, args.long_format, args.show_inode, args.sort_time, args.sort_size, args.reverse, args.recursive, args.classify, args.human_readable, args.follow_links);
     return 0;
 }


### PR DESCRIPTION
## Summary
- parse new `-L` flag in `parse_args`
- store new flag in `Args` struct
- pass `follow_links` to `list_directory`
- optionally call `stat()` when following symlinks
- document flag and default behaviour

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852f073335c832498b3f7fb6c6f6229