### PR TITLE
Add --almost-all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Use `-r` to display entries in reverse alphabetical order.
 Use `-t` to sort entries by modification time.
 Use `-S` to sort entries by file size.
 Use `-i` to display inode numbers.
+Use `-A` or `--almost-all` to show hidden entries except `.` and `..`.
 Use `-R` to recursively list subdirectories (symbolic links are not followed).
 Use `-F` to append indicators to entries: `/` for directories, `*` for executables and `@` for symbolic links.
 Use `-h` to display file sizes in human readable units when combined with `-l`.

--- a/include/args.h
+++ b/include/args.h
@@ -8,6 +8,7 @@ typedef struct {
     size_t path_count;
     int use_color;
     int show_hidden;
+    int almost_all;
     int long_format;
     int show_inode;
     int sort_time;

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links);
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -19,6 +19,9 @@ to follow them.
 .BR -a
 Include directory entries whose names begin with a dot (.).
 .TP
+.BR -A , --almost-all
+List all entries except "." and "..".
+.TP
 .BR -l
 Use a long listing format.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -7,6 +7,7 @@
 void parse_args(int argc, char *argv[], Args *args) {
     args->use_color = 1;
     args->show_hidden = 0;
+    args->almost_all = 0;
     args->long_format = 0;
     args->show_inode = 0;
     args->sort_time = 0;
@@ -21,13 +22,17 @@ void parse_args(int argc, char *argv[], Args *args) {
 
     static struct option long_options[] = {
         {"no-color", no_argument, 0, 'C'},
+        {"almost-all", no_argument, 0, 'A'},
         {"help", no_argument, 0, 1},
         {0, 0, 0, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "ialtrSChRFhL", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrSChRFhL", long_options, NULL)) != -1) {
         switch (opt) {
+        case 'A':
+            args->almost_all = 1;
+            break;
         case 'a':
             args->show_hidden = 1;
             break;
@@ -62,12 +67,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             args->use_color = 0;
             break;
         case 1:
-            printf("Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -71,7 +71,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, int use_color, int show_hidden, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links) {
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links) {
     DIR *dir = opendir(path);
     if (!dir) {
         perror("opendir");
@@ -92,6 +92,8 @@ void list_directory(const char *path, int use_color, int show_hidden, int long_f
 
     while ((entry = readdir(dir)) != NULL) {
         if (!show_hidden && entry->d_name[0] == '.')
+            continue;
+        if (almost_all && (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0))
             continue;
         if (count == capacity) {
             capacity *= 2;
@@ -256,7 +258,7 @@ void list_directory(const char *path, int use_color, int show_hidden, int long_f
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, use_color, show_hidden, long_format, show_inode, sort_time, sort_size, reverse, recursive, classify, human_readable, follow_links);
+            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_size, reverse, recursive, classify, human_readable, follow_links);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,10 +13,11 @@ int main(int argc, char *argv[]) {
         const char *path = args.paths[i];
         if (!args.recursive && args.path_count > 1)
             printf("%s:\n", path);
-        list_directory(path, args.use_color, args.show_hidden, args.long_format,
-                      args.show_inode, args.sort_time, args.sort_size,
-                      args.reverse, args.recursive, args.classify,
-                      args.human_readable, args.follow_links);
+        list_directory(path, args.use_color, args.show_hidden, args.almost_all,
+                      args.long_format, args.show_inode, args.sort_time,
+                      args.sort_size, args.reverse, args.recursive,
+                      args.classify, args.human_readable,
+                      args.follow_links);
         if (i < args.path_count - 1)
             printf("\n");
     }


### PR DESCRIPTION
## Summary
- handle `-A`/`--almost-all` in argument parsing
- skip `.` and `..` entries in `list_directory`
- document the option in README and the man page

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852f4e1af188324a6d2cc0586e8b4c4