### PR TITLE
Implement -d option for listing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Use `-S` to sort entries by file size.
 Use `-i` to display inode numbers.
 Use `-A` or `--almost-all` to show hidden entries except `.` and `..`.
 Use `-R` to recursively list subdirectories (symbolic links are not followed).
+Use `-d` to list directory arguments themselves rather than their contents.
 Use `-F` to append indicators to entries: `/` for directories, `*` for executables and `@` for symbolic links.
 Use `-h` to display file sizes in human readable units when combined with `-l`.
 Use `-L` to follow symbolic links when retrieving file details (the default is to display information about the links themselves).

--- a/include/args.h
+++ b/include/args.h
@@ -15,6 +15,7 @@ typedef struct {
     int sort_size;
     int reverse;
     int recursive;
+    int list_dirs_only;
     int follow_links;
     int human_readable;
     int classify;

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links);
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links, int list_dirs_only);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -40,6 +40,9 @@ Reverse the sort order.
 .BR -R
 List subdirectories recursively (symbolic links are not followed).
 .TP
+.BR -d
+List directory arguments themselves instead of their contents.
+.TP
 .BR -L
 Follow symbolic links when retrieving file details.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -14,6 +14,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->sort_size = 0;
     args->reverse = 0;
     args->recursive = 0;
+    args->list_dirs_only = 0;
     args->classify = 0;
     args->follow_links = 0;
     args->human_readable = 0;
@@ -28,7 +29,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtrSChRFhL", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrSChRFhLd", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -54,6 +55,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'R':
             args->recursive = 1;
             break;
+        case 'd':
+            args->list_dirs_only = 1;
+            break;
         case 'F':
             args->classify = 1;
             break;
@@ -67,12 +71,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             args->use_color = 0;
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -11,13 +11,13 @@ int main(int argc, char *argv[]) {
     printf("vls %s\n", VLS_VERSION);
     for (size_t i = 0; i < args.path_count; i++) {
         const char *path = args.paths[i];
-        if (!args.recursive && args.path_count > 1)
+        if (!args.recursive && args.path_count > 1 && !args.list_dirs_only)
             printf("%s:\n", path);
         list_directory(path, args.use_color, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
                       args.sort_size, args.reverse, args.recursive,
                       args.classify, args.human_readable,
-                      args.follow_links);
+                      args.follow_links, args.list_dirs_only);
         if (i < args.path_count - 1)
             printf("\n");
     }


### PR DESCRIPTION
## Summary
- allow listing directories without descending via new `-d` flag
- handle `-d` in argument parser
- print given directory names when `-d` is enabled
- document new option in README and man page

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6852fedf1f588324ab45a0b14da0284a