### PR TITLE
Add numeric uid/gid display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Use `-d` to list directory arguments themselves rather than their contents.
 Use `-F` to append indicators to entries: `/` for directories, `*` for executables and `@` for symbolic links.
 Use `-h` to display file sizes in human readable units when combined with `-l`.
 Use `-L` to follow symbolic links when retrieving file details (the default is to display information about the links themselves).
+Use `-n` to show numeric user and group IDs in long-format output.
 You may specify one or more paths to list. When multiple targets are given,
 `vls` prints a heading before each listing just like `ls`.
 

--- a/include/args.h
+++ b/include/args.h
@@ -19,6 +19,7 @@ typedef struct {
     int list_dirs_only;
     int follow_links;
     int human_readable;
+    int numeric_ids;
     int classify;
 } Args;
 

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links, int list_dirs_only);
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int human_readable, int numeric_ids, int follow_links, int list_dirs_only);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -59,6 +59,9 @@ With
 .BR -l ,
 print sizes in human readable format.
 .TP
+.BR -n
+Display numeric user and group IDs in long format output.
+.TP
 .BR --no-color
 Disable colored output.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -19,6 +19,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->classify = 0;
     args->follow_links = 0;
     args->human_readable = 0;
+    args->numeric_ids = 0;
     args->paths = NULL;
     args->path_count = 0;
 
@@ -30,7 +31,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruSChRFhLd", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtruSChRFhLdn", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -71,16 +72,19 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'h':
             args->human_readable = 1;
             break;
+        case 'n':
+            args->numeric_ids = 1;
+            break;
         case 'C':
             args->use_color = 0;
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [-n] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-L] [-F] [-h] [-n] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -79,7 +79,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int human_readable, int follow_links, int list_dirs_only) {
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int human_readable, int numeric_ids, int follow_links, int list_dirs_only) {
     if (list_dirs_only) {
         struct stat st;
         int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
@@ -116,14 +116,14 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             else
                 snprintf(size_buf, sizeof(size_buf), "%lld", (long long)st.st_size);
 
-            struct passwd *pw = getpwuid(st.st_uid);
+            struct passwd *pw = numeric_ids ? NULL : getpwuid(st.st_uid);
             char owner_buf[32];
             if (pw)
                 snprintf(owner_buf, sizeof(owner_buf), "%s", pw->pw_name);
             else
                 snprintf(owner_buf, sizeof(owner_buf), "%u", st.st_uid);
 
-            struct group *gr = getgrgid(st.st_gid);
+            struct group *gr = numeric_ids ? NULL : getgrgid(st.st_gid);
             char group_buf[32];
             if (gr)
                 snprintf(group_buf, sizeof(group_buf), "%s", gr->gr_name);
@@ -239,12 +239,12 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             if (num_digits(ent->st.st_nlink) > link_w)
                 link_w = num_digits(ent->st.st_nlink);
 
-            struct passwd *pw = getpwuid(ent->st.st_uid);
+            struct passwd *pw = numeric_ids ? NULL : getpwuid(ent->st.st_uid);
             size_t len = pw ? strlen(pw->pw_name) : num_digits(ent->st.st_uid);
             if (len > owner_w)
                 owner_w = len;
 
-            struct group *gr = getgrgid(ent->st.st_gid);
+            struct group *gr = numeric_ids ? NULL : getgrgid(ent->st.st_gid);
             len = gr ? strlen(gr->gr_name) : num_digits(ent->st.st_gid);
             if (len > group_w)
                 group_w = len;
@@ -292,14 +292,14 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             else
                 snprintf(size_buf, sizeof(size_buf), "%lld", (long long)ent->st.st_size);
 
-            struct passwd *pw = getpwuid(ent->st.st_uid);
+            struct passwd *pw = numeric_ids ? NULL : getpwuid(ent->st.st_uid);
             char owner_buf[32];
             if (pw)
                 snprintf(owner_buf, sizeof(owner_buf), "%s", pw->pw_name);
             else
                 snprintf(owner_buf, sizeof(owner_buf), "%u", ent->st.st_uid);
 
-            struct group *gr = getgrgid(ent->st.st_gid);
+            struct group *gr = numeric_ids ? NULL : getgrgid(ent->st.st_gid);
             char group_buf[32];
             if (gr)
                 snprintf(group_buf, sizeof(group_buf), "%s", gr->gr_name);
@@ -363,7 +363,7 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, human_readable, follow_links, list_dirs_only);
+            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, human_readable, numeric_ids, follow_links, list_dirs_only);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
         list_directory(path, args.use_color, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
                       args.sort_atime, args.sort_size, args.reverse, args.recursive,
-                      args.classify, args.human_readable,
+                      args.classify, args.human_readable, args.numeric_ids,
                       args.follow_links, args.list_dirs_only);
         if (i < args.path_count - 1)
             printf("\n");


### PR DESCRIPTION
## Summary
- add `numeric_ids` option to argument parser
- handle `-n` in args and pass to listing routine
- output numeric owner/group IDs when `-n` is set
- document the new option in README and man page

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853019eeb08832498b6070d5fb5b554