### PR TITLE
Add ignore-backups option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use `-L` to follow symbolic links when retrieving file details (the default is t
 Use `-n` to show numeric user and group IDs in long-format output.
 Use `-g` to omit owner names in long format.
 Use `-o` to omit group names in long format.
+Use `-B` or `--ignore-backups` to skip entries ending with '~'.
 You may specify one or more paths to list. When multiple targets are given,
 `vls` prints a heading before each listing just like `ls`.
 

--- a/include/args.h
+++ b/include/args.h
@@ -24,6 +24,7 @@ typedef struct {
     int hide_group;
     int classify;
     int slash_dirs;
+    int ignore_backups;
 } Args;
 
 void parse_args(int argc, char *argv[], Args *args);

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,6 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only);
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -71,6 +71,9 @@ Omit the owner column in long format output.
 .BR -o
 Omit the group column in long format output.
 .TP
+.BR -B , --ignore-backups
+Do not list files ending with '~'.
+.TP
 .BR --no-color
 Disable colored output.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -23,18 +23,20 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->numeric_ids = 0;
     args->hide_owner = 0;
     args->hide_group = 0;
+    args->ignore_backups = 0;
     args->paths = NULL;
     args->path_count = 0;
 
     static struct option long_options[] = {
         {"no-color", no_argument, 0, 'C'},
         {"almost-all", no_argument, 0, 'A'},
+        {"ignore-backups", no_argument, 0, 'B'},
         {"help", no_argument, 0, 1},
         {0, 0, 0, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruSChRFphLdgon", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtruSChRFpBhLdgon", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -69,6 +71,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'p':
             args->slash_dirs = 1;
             break;
+        case 'B':
+            args->ignore_backups = 1;
+            break;
         case 'F':
             args->classify = 1;
             break;
@@ -91,12 +96,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             args->use_color = 0;
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -79,7 +79,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only) {
+void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups) {
     if (list_dirs_only) {
         struct stat st;
         int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
@@ -196,6 +196,11 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             continue;
         if (almost_all && (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0))
             continue;
+        if (ignore_backups) {
+            size_t len = strlen(entry->d_name);
+            if (len > 0 && entry->d_name[len - 1] == '~')
+                continue;
+        }
         if (count == capacity) {
             capacity *= 2;
             Entry *tmp = realloc(entries, capacity * sizeof(Entry));
@@ -362,7 +367,7 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only);
+            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
                       args.sort_atime, args.sort_size, args.reverse, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
-                      args.follow_links, args.list_dirs_only);
+                      args.follow_links, args.list_dirs_only, args.ignore_backups);
         if (i < args.path_count - 1)
             printf("\n");
     }


### PR DESCRIPTION
## Summary
- implement `-B`/`--ignore-backups` flag
- skip files ending with `~` when flag set
- document the new option in README and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685307fa75208324aee2916853c1e9e2