### PR TITLE
Add --color option and LS_COLORS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build:
 test: build/vls
 	./build/vls -a > /dev/null
 	./build/vls -l > /dev/null
-	./build/vls --no-color > /dev/null
+	./build/vls --color=never > /dev/null
 	@echo "Tests completed"
 
 install: build/vls

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ ls replacement utility for UNIX
 vls is a minimal tool intended as a replacement for the standard `ls` command.
 
 File names are colorized based on type (directories, links and executables).
-Pass `--no-color` to disable colored output.
+Use `--color=WHEN` to control coloring where `WHEN` is `auto`, `always` or `never`.
+Color definitions respect the `LS_COLORS` environment variable when set.
 Use `-r` to display entries in reverse alphabetical order.
 Use `-t` to sort entries by modification time.
 Use `-u` to sort entries by access time. With `-l`, access time is shown.

--- a/include/args.h
+++ b/include/args.h
@@ -3,10 +3,16 @@
 
 #include <stddef.h>
 
+typedef enum {
+    COLOR_NEVER,
+    COLOR_ALWAYS,
+    COLOR_AUTO
+} ColorMode;
+
 typedef struct {
     const char **paths;
     size_t path_count;
-    int use_color;
+    ColorMode color_mode;
     int show_hidden;
     int almost_all;
     int long_format;

--- a/include/color.h
+++ b/include/color.h
@@ -5,5 +5,6 @@ const char *color_reset(void);
 const char *color_dir(void);
 const char *color_link(void);
 const char *color_exec(void);
+void color_init(void);
 
 #endif // COLOR_H

--- a/include/list.h
+++ b/include/list.h
@@ -1,6 +1,8 @@
 #ifndef LIST_H
 #define LIST_H
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups);
+#include "args.h"
+
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -8,9 +8,9 @@ vls \- colorized ls replacement
 .B vls
 is a minimal utility that lists directory contents similarly to
 .BR ls (1).
-File names are colorized by default. Use
-.BR --no-color
- to disable colors.
+File names are colorized by default. The option
+.BR --color=WHEN
+controls coloring where WHEN is \fIauto\fP, \fIalways\fP or \fInever\fP.
 Default behavior is to display information about symbolic links. Use
 .BR -L
 to follow them.
@@ -74,8 +74,8 @@ Omit the group column in long format output.
 .BR -B , --ignore-backups
 Do not list files ending with '~'.
 .TP
-.BR --no-color
-Disable colored output.
+.BR --color=WHEN
+Control colorization. WHEN is \fIauto\fP, \fIalways\fP or \fInever\fP.
 .TP
 .BR --help
 Display a brief usage message and exit.
@@ -90,7 +90,7 @@ List all files in long format.
 .B vls -tR /etc
 Recursively list /etc sorted by modification time.
 .TP
-.B vls --no-color
+.B vls --color=never
 List current directory without colorization.
 .SH SEE ALSO
 .BR ls (1)

--- a/src/args.c
+++ b/src/args.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 void parse_args(int argc, char *argv[], Args *args) {
-    args->use_color = 1;
+    args->color_mode = COLOR_AUTO;
     args->show_hidden = 0;
     args->almost_all = 0;
     args->long_format = 0;
@@ -28,7 +28,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->path_count = 0;
 
     static struct option long_options[] = {
-        {"no-color", no_argument, 0, 'C'},
+        {"color", required_argument, 0, 2},
         {"almost-all", no_argument, 0, 'A'},
         {"ignore-backups", no_argument, 0, 'B'},
         {"help", no_argument, 0, 1},
@@ -36,7 +36,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruSChRFpBhLdgon", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtruShRFpBhLdgon", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -92,16 +92,25 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'n':
             args->numeric_ids = 1;
             break;
-        case 'C':
-            args->use_color = 0;
+        case 2:
+            if (strcmp(optarg, "always") == 0)
+                args->color_mode = COLOR_ALWAYS;
+            else if (strcmp(optarg, "auto") == 0)
+                args->color_mode = COLOR_AUTO;
+            else if (strcmp(optarg, "never") == 0)
+                args->color_mode = COLOR_NEVER;
+            else {
+                fprintf(stderr, "Invalid argument for --color: %s\n", optarg);
+                exit(1);
+            }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--no-color] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/color.c
+++ b/src/color.c
@@ -1,6 +1,40 @@
 #include "color.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
 
-const char *color_reset(void) { return "\x1b[0m"; }
-const char *color_dir(void)   { return "\x1b[1;34m"; }
-const char *color_link(void)  { return "\x1b[1;36m"; }
-const char *color_exec(void)  { return "\x1b[1;32m"; }
+static char reset_str[32] = "\x1b[0m";
+static char dir_str[32]   = "\x1b[1;34m";
+static char link_str[32]  = "\x1b[1;36m";
+static char exec_str[32]  = "\x1b[1;32m";
+
+static void set_color(char *buf, size_t sz, const char *code) {
+    snprintf(buf, sz, "\x1b[%sm", code);
+}
+
+void color_init(void) {
+    const char *env = getenv("LS_COLORS");
+    if (!env)
+        return;
+    char *tmp = strdup(env);
+    if (!tmp)
+        return;
+    char *tok = strtok(tmp, ":");
+    while (tok) {
+        if (strncmp(tok, "di=", 3) == 0)
+            set_color(dir_str, sizeof(dir_str), tok + 3);
+        else if (strncmp(tok, "ln=", 3) == 0)
+            set_color(link_str, sizeof(link_str), tok + 3);
+        else if (strncmp(tok, "ex=", 3) == 0)
+            set_color(exec_str, sizeof(exec_str), tok + 3);
+        else if (strncmp(tok, "rs=", 3) == 0)
+            set_color(reset_str, sizeof(reset_str), tok + 3);
+        tok = strtok(NULL, ":");
+    }
+    free(tmp);
+}
+
+const char *color_reset(void) { return reset_str; }
+const char *color_dir(void)   { return dir_str; }
+const char *color_link(void)  { return link_str; }
+const char *color_exec(void)  { return exec_str; }

--- a/src/list.c
+++ b/src/list.c
@@ -79,7 +79,12 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, int use_color, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups) {
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups) {
+    int use_color = 0;
+    if (color_mode == COLOR_ALWAYS)
+        use_color = 1;
+    else if (color_mode == COLOR_AUTO)
+        use_color = isatty(STDOUT_FILENO);
     if (list_dirs_only) {
         struct stat st;
         int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
@@ -367,7 +372,7 @@ void list_directory(const char *path, int use_color, int show_hidden, int almost
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, use_color, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups);
+            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,19 +1,21 @@
 #include <stdio.h>
 #include "list.h"
 #include "args.h"
+#include "color.h"
 
 #define VLS_VERSION "0.1"
 
 int main(int argc, char *argv[]) {
     Args args;
     parse_args(argc, argv, &args);
+    color_init();
 
     printf("vls %s\n", VLS_VERSION);
     for (size_t i = 0; i < args.path_count; i++) {
         const char *path = args.paths[i];
         if (!args.recursive && args.path_count > 1 && !args.list_dirs_only)
             printf("%s:\n", path);
-        list_directory(path, args.use_color, args.show_hidden, args.almost_all,
+        list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
                       args.sort_atime, args.sort_size, args.reverse, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,


### PR DESCRIPTION
## Summary
- introduce `ColorMode` enum with auto/always/never
- parse `--color=WHEN` and honor `$LS_COLORS`
- adapt listing logic to new color mode
- document new option in README and man page

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68530a89bf5c83248c33466540568af4