### PR TITLE
Add unsorted option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Use `-r` to display entries in reverse alphabetical order.
 Use `-t` to sort entries by modification time.
 Use `-u` to sort entries by access time. With `-l`, access time is shown.
 Use `-S` to sort entries by file size.
+Use `-f` (or `-U`) to disable sorting and list entries in directory order.
 Use `-i` to display inode numbers.
 Use `-A` or `--almost-all` to show hidden entries except `.` and `..`.
 Use `-R` to recursively list subdirectories (symbolic links are not followed).

--- a/include/args.h
+++ b/include/args.h
@@ -20,6 +20,7 @@ typedef struct {
     int sort_time;
     int sort_atime;
     int sort_size;
+    int unsorted;
     int reverse;
     int recursive;
     int list_dirs_only;

--- a/include/list.h
+++ b/include/list.h
@@ -3,6 +3,6 @@
 
 #include "args.h"
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -39,6 +39,9 @@ display access time instead of modification time.
 .BR -S
 Sort by file size, largest first.
 .TP
+.BR -f , -U
+Do not sort; list entries in directory order.
+.TP
 .BR -r
 Reverse the sort order.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -14,6 +14,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->sort_time = 0;
     args->sort_atime = 0;
     args->sort_size = 0;
+    args->unsorted = 0;
     args->reverse = 0;
     args->recursive = 0;
     args->list_dirs_only = 0;
@@ -39,7 +40,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruShRFpBhLdgonC1", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtruUfhRFpBhLdgonC1", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -61,6 +62,10 @@ void parse_args(int argc, char *argv[], Args *args) {
             break;
         case 'S':
             args->sort_size = 1;
+            break;
+        case 'f':
+        case 'U':
+            args->unsorted = 1;
             break;
         case 'r':
             args->reverse = 1;
@@ -114,12 +119,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -80,7 +80,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
     int use_color = 0;
     if (color_mode == COLOR_ALWAYS)
         use_color = 1;
@@ -232,14 +232,16 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
         count++;
     }
 
-    int (*cmp)(const void *, const void *) = cmp_names;
-    if (sort_size)
-        cmp = cmp_size;
-    else if (sort_time)
-        cmp = cmp_mtime;
-    else if (sort_atime)
-        cmp = cmp_atime;
-    qsort(entries, count, sizeof(Entry), cmp);
+    if (!unsorted) {
+        int (*cmp)(const void *, const void *) = cmp_names;
+        if (sort_size)
+            cmp = cmp_size;
+        else if (sort_time)
+            cmp = cmp_mtime;
+        else if (sort_atime)
+            cmp = cmp_atime;
+        qsort(entries, count, sizeof(Entry), cmp);
+    }
 
     size_t link_w = 0, owner_w = 0, group_w = 0, size_w = 0;
     size_t max_len = 0;
@@ -441,7 +443,7 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
+            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, unsorted, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
             printf("%s:\n", path);
         list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
-                      args.sort_atime, args.sort_size, args.reverse, args.recursive,
+                      args.sort_atime, args.sort_size, args.unsorted, args.reverse, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
                       args.follow_links, args.list_dirs_only, args.ignore_backups,


### PR DESCRIPTION
## Summary
- add `unsorted` flag to `Args`
- handle `-f`/`-U` options for unsorted listing
- skip sorting when `unsorted` is set
- document the new option in README and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685332d167888324a72e5b27eaa2a8e6