### PR TITLE
Add extension sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Use `-r` to display entries in reverse alphabetical order.
 Use `-t` to sort entries by modification time.
 Use `-u` to sort entries by access time. With `-l`, access time is shown.
 Use `-S` to sort entries by file size.
+Use `-X` to sort entries by file extension.
 Use `-f` (or `-U`) to disable sorting and list entries in directory order.
 Use `-i` to display inode numbers.
 Use `-A` or `--almost-all` to show hidden entries except `.` and `..`.

--- a/include/args.h
+++ b/include/args.h
@@ -20,6 +20,7 @@ typedef struct {
     int sort_time;
     int sort_atime;
     int sort_size;
+    int sort_extension;
     int unsorted;
     int reverse;
     int recursive;

--- a/include/list.h
+++ b/include/list.h
@@ -3,6 +3,6 @@
 
 #include "args.h"
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -39,6 +39,9 @@ display access time instead of modification time.
 .BR -S
 Sort by file size, largest first.
 .TP
+.BR -X
+Sort by file extension, case-insensitive.
+.TP
 .BR -f , -U
 Do not sort; list entries in directory order.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -14,6 +14,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->sort_time = 0;
     args->sort_atime = 0;
     args->sort_size = 0;
+    args->sort_extension = 0;
     args->unsorted = 0;
     args->reverse = 0;
     args->recursive = 0;
@@ -40,7 +41,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruUfhRFpBhLdgonC1", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtruUfhXRFpBhLdgonC1", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -62,6 +63,9 @@ void parse_args(int argc, char *argv[], Args *args) {
             break;
         case 'S':
             args->sort_size = 1;
+            break;
+        case 'X':
+            args->sort_extension = 1;
             break;
         case 'f':
         case 'U':
@@ -119,12 +123,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <string.h>
+#include <strings.h>
 #include <limits.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -57,6 +58,19 @@ static int cmp_size(const void *a, const void *b) {
     return (ea->st.st_size > eb->st.st_size) ? -1 : 1;
 }
 
+static int cmp_extension(const void *a, const void *b) {
+    const Entry *ea = a;
+    const Entry *eb = b;
+    const char *ea_ext = strrchr(ea->name, '.');
+    const char *eb_ext = strrchr(eb->name, '.');
+    ea_ext = ea_ext ? ea_ext + 1 : ea->name;
+    eb_ext = eb_ext ? eb_ext + 1 : eb->name;
+    int cmp = strcasecmp(ea_ext, eb_ext);
+    if (cmp == 0)
+        return strcasecmp(ea->name, eb->name);
+    return cmp;
+}
+
 static void human_size(off_t size, char *buf, size_t bufsz) {
     const char suffixes[] = {'B','K','M','G','T','P'};
     double s = (double)size;
@@ -80,7 +94,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
     int use_color = 0;
     if (color_mode == COLOR_ALWAYS)
         use_color = 1;
@@ -240,6 +254,8 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             cmp = cmp_mtime;
         else if (sort_atime)
             cmp = cmp_atime;
+        else if (sort_extension)
+            cmp = cmp_extension;
         qsort(entries, count, sizeof(Entry), cmp);
     }
 
@@ -443,7 +459,7 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, unsorted, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
+            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, sort_extension, unsorted, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
             printf("%s:\n", path);
         list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
-                      args.sort_atime, args.sort_size, args.unsorted, args.reverse, args.recursive,
+                      args.sort_atime, args.sort_size, args.sort_extension, args.unsorted, args.reverse, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
                       args.follow_links, args.list_dirs_only, args.ignore_backups,


### PR DESCRIPTION
## Summary
- allow `-X` to sort entries by file extension
- implement case-insensitive extension comparator
- document new flag in README and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68535589b71c8324a71561016dd726d2