### PR TITLE
Add ctime sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Color definitions respect the `LS_COLORS` environment variable when set.
 Use `-r` to display entries in reverse alphabetical order.
 Use `-t` to sort entries by modification time.
 Use `-u` to sort entries by access time. With `-l`, access time is shown.
+Use `-c` to sort entries by status change time. With `-l`, change time is shown.
 Use `-S` to sort entries by file size.
 Use `-X` to sort entries by file extension.
 Use `-f` (or `-U`) to disable sorting and list entries in directory order.

--- a/include/args.h
+++ b/include/args.h
@@ -19,6 +19,7 @@ typedef struct {
     int show_inode;
     int sort_time;
     int sort_atime;
+    int sort_ctime;
     int sort_size;
     int sort_extension;
     int unsorted;

--- a/include/list.h
+++ b/include/list.h
@@ -3,6 +3,6 @@
 
 #include "args.h"
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -36,6 +36,11 @@ Sort by access time, newest first. When combined with
 .BR -l ,
 display access time instead of modification time.
 .TP
+.BR -c
+Sort by status change time, newest first. When combined with
+.BR -l ,
+display change time instead of modification time.
+.TP
 .BR -S
 Sort by file size, largest first.
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -13,6 +13,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->show_inode = 0;
     args->sort_time = 0;
     args->sort_atime = 0;
+    args->sort_ctime = 0;
     args->sort_size = 0;
     args->sort_extension = 0;
     args->unsorted = 0;
@@ -41,7 +42,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtruUfhXRFpBhLdgonC1", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrucUfhXRFpBhLdgonC1", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -60,6 +61,9 @@ void parse_args(int argc, char *argv[], Args *args) {
             break;
         case 'u':
             args->sort_atime = 1;
+            break;
+        case 'c':
+            args->sort_ctime = 1;
             break;
         case 'S':
             args->sort_size = 1;
@@ -123,12 +127,12 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-B] [-L] [-F] [-C] [-1] [-h] [-n] [-g] [-o] [--color=WHEN] [--almost-all] [--help] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -50,6 +50,14 @@ static int cmp_atime(const void *a, const void *b) {
     return (ea->st.st_atime > eb->st.st_atime) ? -1 : 1;
 }
 
+static int cmp_ctime(const void *a, const void *b) {
+    const Entry *ea = a;
+    const Entry *eb = b;
+    if (ea->st.st_ctime == eb->st.st_ctime)
+        return 0;
+    return (ea->st.st_ctime > eb->st.st_ctime) ? -1 : 1;
+}
+
 static int cmp_size(const void *a, const void *b) {
     const Entry *ea = a;
     const Entry *eb = b;
@@ -94,7 +102,7 @@ static size_t num_digits(unsigned long long n) {
     return d;
 }
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int unsorted, int reverse, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int follow_links, int list_dirs_only, int ignore_backups, int columns, int one_per_line) {
     int use_color = 0;
     if (color_mode == COLOR_ALWAYS)
         use_color = 1;
@@ -171,7 +179,8 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             perms[10] = '\0';
 
             char time_buf[32];
-            struct tm *tm = localtime(sort_atime ? &st.st_atime : &st.st_mtime);
+            struct tm *tm = localtime(sort_atime ? &st.st_atime :
+                                       sort_ctime ? &st.st_ctime : &st.st_mtime);
             strftime(time_buf, sizeof(time_buf), "%b %e %H:%M", tm);
 
             if (show_inode)
@@ -254,6 +263,8 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             cmp = cmp_mtime;
         else if (sort_atime)
             cmp = cmp_atime;
+        else if (sort_ctime)
+            cmp = cmp_ctime;
         else if (sort_extension)
             cmp = cmp_extension;
         qsort(entries, count, sizeof(Entry), cmp);
@@ -425,7 +436,9 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             perms[10] = '\0';
 
             char time_buf[32];
-            struct tm *tm = localtime(sort_atime ? &ent->st.st_atime : &ent->st.st_mtime);
+            struct tm *tm = localtime(sort_atime ? &ent->st.st_atime :
+                                       sort_ctime ? &ent->st.st_ctime :
+                                       &ent->st.st_mtime);
             strftime(time_buf, sizeof(time_buf), "%b %e %H:%M", tm);
 
             if (show_inode)
@@ -459,7 +472,7 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_size, sort_extension, unsorted, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
+            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_ctime, sort_size, sort_extension, unsorted, reverse, recursive, classify, slash_dirs, human_readable, numeric_ids, hide_owner, hide_group, follow_links, list_dirs_only, ignore_backups, columns, one_per_line);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
             printf("%s:\n", path);
         list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
-                      args.sort_atime, args.sort_size, args.sort_extension, args.unsorted, args.reverse, args.recursive,
+                      args.sort_atime, args.sort_ctime, args.sort_size, args.sort_extension, args.unsorted, args.reverse, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
                       args.follow_links, args.list_dirs_only, args.ignore_backups,


### PR DESCRIPTION
## Summary
- parse `-c` option for ctime based sorting
- allow `cmp_ctime` comparison and display ctime in long format
- add sort_ctime field to `Args` and update `list_directory`
- document new option in README and man page

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685357f624b48324a269834e54cb7dd5