### PR TITLE
Add total block count output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Use `-F` to append indicators to entries: `/` for directories, `*` for executabl
 Use `-p` to append '/' to directory names.
 Use `-s` to display the number of blocks allocated to each file.
 Use `--block-size=SIZE` to override the default block size (512 or 1024 bytes).
+When `-l` or `-s` is specified, `vls` prints a `total <num>` line before the
+listing. The count sums the blocks of the shown files using the selected block
+size.
 Use `-h` to display file sizes in human readable units when combined with `-l`.
 Use `-L` to follow symbolic links when retrieving file details (the default is to display information about the links themselves).
 Use `-n` to show numeric user and group IDs in long-format output.

--- a/man/vls.1
+++ b/man/vls.1
@@ -70,6 +70,15 @@ Append '/' to directory names.
 .TP
 .BR -s
 Display the number of blocks allocated to each file.
+.br
+When used with
+.B -l
+or
+.B -s,
+a line of the form
+.B "total <num>"
+appears before the listing showing the sum of blocks for the displayed files
+according to the current block size.
 .TP
 .BR --block-size=SIZE
 Override the default block size (512 or 1024 bytes).


### PR DESCRIPTION
## Summary
- compute total blocks once for the listed files
- print the `total <num>` line when `-l` or `-s` is used
- document new behaviour in README and the man page

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68535b991fcc83248e64578ff38cd9b2