### PR TITLE
Add -k option for 1KiB block size

### DIFF
--- a/man/vls.1
+++ b/man/vls.1
@@ -86,6 +86,9 @@ according to the current block size.
 .BR --block-size=SIZE
 Override the default block size (512 or 1024 bytes).
 .TP
+.BR -k
+Use 1 KiB blocks for size calculations.
+.TP
 .BR -h
 With
 .BR -l ,

--- a/src/args.c
+++ b/src/args.c
@@ -56,7 +56,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtrucUfhXRFpI:BhLdgonCx1msQV", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrucUfhXRFpI:BhLdgonCx1msQVk", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -151,6 +151,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'Q':
             args->quote_names = 1;
             break;
+        case 'k':
+            args->block_size = 1024;
+            break;
         case 3:
             args->block_size = (unsigned)strtoul(optarg, NULL, 10);
             if (args->block_size == 0) {
@@ -174,7 +177,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them.\n");
             exit(0);
             break;
@@ -183,7 +186,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -29,6 +29,7 @@ vls - colorized ls replacement
 - `-p` Append '/' to directory names.
 - `-s` Display the number of blocks allocated to each file. When used with `-l` or `-s`, a line of the form `total <num>` appears before the listing showing the sum of blocks for the displayed files according to the current block size.
 - `--block-size=SIZE` Override the default block size (512 or 1024 bytes).
+- `-k` Use 1 KiB blocks for size calculations.
 - `-h` With `-l`, print sizes in human readable format.
 - `-n` Display numeric user and group IDs in long format output.
 - `-g` Omit the owner column in long format output.


### PR DESCRIPTION
## Summary
- support `-k` short option in argument parser
- document new flag in manual and docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68538898151c83249181b2126a241f58