### PR TITLE
Add -H option to follow cmdline symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A minimal, colorized replacement for `ls`.
 - Supports long listings and various sorting modes (time, size, extension)
 - Recursive listing and directory-first ordering
 - Pattern ignoring and indicator characters ("/", "*", "@")
+- Optional dereferencing of command line symlinks (`-H`)
 - Options for quoting names, human readable sizes, column layout (`-C`/`-x`) and comma-separated output (`-m`)
 - Cross‑platform Makefile for Linux, macOS and NetBSD
 

--- a/include/args.h
+++ b/include/args.h
@@ -28,6 +28,7 @@ typedef struct {
     int recursive;
     int list_dirs_only;
     int follow_links;
+    int deref_cmdline;
     int human_readable;
     int numeric_ids;
     int hide_owner;

--- a/man/vls.1
+++ b/man/vls.1
@@ -13,7 +13,9 @@ File names are colorized by default. The option
 controls coloring where WHEN is \fIauto\fP, \fIalways\fP or \fInever\fP.
 Default behavior is to display information about symbolic links. Use
 .BR -L
-to follow them.
+to follow them or
+.BR -H
+for command line paths only.
 .SH OPTIONS
 .TP
 .BR -a
@@ -64,6 +66,9 @@ List directory arguments themselves instead of their contents.
 .TP
 .BR -L
 Follow symbolic links when retrieving file details.
+.TP
+.BR -H
+Follow symbolic links specified on the command line.
 .TP
 .BR -F
 Append indicator characters to entries: '/' for directories, '*' for executables and '@' for symbolic links.

--- a/src/args.c
+++ b/src/args.c
@@ -25,6 +25,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->classify = 0;
     args->slash_dirs = 0;
     args->follow_links = 0;
+    args->deref_cmdline = 0;
     args->human_readable = 0;
     args->numeric_ids = 0;
     args->hide_owner = 0;
@@ -56,7 +57,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtrucUfhXRFpI:BhLdgonCx1msQVk", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrucUfhXRFpI:BhHLdgonCx1msQVk", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -133,6 +134,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'L':
             args->follow_links = 1;
             break;
+        case 'H':
+            args->deref_cmdline = 1;
+            break;
         case 's':
             args->show_blocks = 1;
             break;
@@ -177,8 +181,8 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
-            printf("Default is to display information about symbolic links. Use -L to follow them.\n");
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            printf("Default is to display information about symbolic links. Use -L to follow them or -H for command line arguments only.\n");
             exit(0);
             break;
         case 'V':
@@ -186,7 +190,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "list.h"
 #include "args.h"
 #include "color.h"
+#include <sys/stat.h>
 
 static void print_quoted(const char *s, int quote) {
     if (!quote) {
@@ -27,9 +28,34 @@ int main(int argc, char *argv[]) {
             print_quoted(path, args.quote_names);
             printf(":\n");
         }
+
+        if (args.deref_cmdline) {
+            struct stat st;
+            if (stat(path, &st) == -1) {
+                perror("stat");
+                continue;
+            }
+            if (args.list_dirs_only || !S_ISDIR(st.st_mode)) {
+                list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
+                              args.long_format, args.show_inode, args.sort_time,
+                              args.sort_atime, args.sort_ctime, args.sort_size, args.sort_extension,
+                              args.unsorted, args.reverse, args.dirs_first, args.recursive,
+                              args.classify, args.slash_dirs, args.human_readable,
+                              args.numeric_ids, args.hide_owner, args.hide_group,
+                              1, 1, args.ignore_backups,
+                                args.ignore_patterns, args.ignore_count, args.columns,
+                                args.across_columns, args.one_per_line, args.comma_separated,
+                                args.show_blocks, args.quote_names, args.block_size);
+                if (i < args.path_count - 1)
+                    printf("\n");
+                continue;
+            }
+        }
+
         list_directory(path, args.color_mode, args.show_hidden, args.almost_all,
                       args.long_format, args.show_inode, args.sort_time,
-                      args.sort_atime, args.sort_ctime, args.sort_size, args.sort_extension, args.unsorted, args.reverse, args.dirs_first, args.recursive,
+                      args.sort_atime, args.sort_ctime, args.sort_size, args.sort_extension,
+                      args.unsorted, args.reverse, args.dirs_first, args.recursive,
                       args.classify, args.slash_dirs, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
                       args.follow_links, args.list_dirs_only, args.ignore_backups,

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -7,7 +7,7 @@ vls - colorized ls replacement
 `vls [OPTION]... [FILE]...`
 
 ## Description
-`vls` is a minimal utility that lists directory contents similarly to `ls`. File names are colorized by default. The option `--color=WHEN` controls coloring where WHEN is `auto`, `always` or `never`. The default is to display information about symbolic links. Use `-L` to follow them.
+`vls` is a minimal utility that lists directory contents similarly to `ls`. File names are colorized by default. The option `--color=WHEN` controls coloring where WHEN is `auto`, `always` or `never`. The default is to display information about symbolic links. Use `-L` to follow them or `-H` for command line paths only.
 
 ## Options
 - `-a` Include directory entries whose names begin with a dot (.).
@@ -25,6 +25,7 @@ vls - colorized ls replacement
 - `-R` List subdirectories recursively (symbolic links are not followed).
 - `-d` List directory arguments themselves instead of their contents.
 - `-L` Follow symbolic links when retrieving file details.
+- `-H` Follow symbolic links specified on the command line.
 - `-F` Append indicator characters to entries: `/` for directories, `*` for executables and `@` for symbolic links.
 - `-p` Append '/' to directory names.
 - `-s` Display the number of blocks allocated to each file. When used with `-l` or `-s`, a line of the form `total <num>` appears before the listing showing the sum of blocks for the displayed files according to the current block size.


### PR DESCRIPTION
## Summary
- add `deref_cmdline` to `Args`
- parse `-H` flag
- dereference command line symlinks in `main`
- document new flag in README, docs and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685389d4ada4832494763f4d39254607