### PR TITLE
Add -b flag for escaping non-printable chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A minimal, colorized replacement for `ls`.
 - Optional dereferencing of command line symlinks (`-H`)
 - Optional display of SELinux contexts (`-Z`, Linux only)
 - Options for quoting names, human readable sizes, column layout (`-C`/`-x`) and comma-separated output (`-m`)
+- Backslash-escapes for non-printable characters (`-b`)
 - Cross‑platform Makefile for Linux, macOS and NetBSD
 
 For a complete list of options see [vlsdoc.md](./vlsdoc.md) or the manual page at [man/vls.1](./man/vls.1).

--- a/include/args.h
+++ b/include/args.h
@@ -46,6 +46,7 @@ typedef struct {
     int comma_separated;
     int show_blocks;
     int quote_names;
+    int escape_nonprint;
     unsigned block_size;
 } Args;
 

--- a/include/list.h
+++ b/include/list.h
@@ -3,6 +3,6 @@
 
 #include "args.h"
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, unsigned block_size);
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, int escape_nonprint, unsigned block_size);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -136,6 +136,9 @@ Print entries separated by ", " wrapping lines to terminal width.
 Quote file names with double quotes, escaping internal quotes and
 backslashes.
 .TP
+.BR -b
+Output backslash escapes for non-printable characters.
+.TP
 .BR -1
 List one entry per line.
 .TP
@@ -163,5 +166,8 @@ List current directory without colorization.
 .TP
 .B vls -I '*.o'
 Ignore files ending in .o
+.TP
+.B vls -b
+Escape non-printable characters with backslash codes
 .SH SEE ALSO
 .BR ls (1)

--- a/src/args.c
+++ b/src/args.c
@@ -41,6 +41,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->comma_separated = 0;
     args->show_blocks = 0;
     args->quote_names = 0;
+    args->escape_nonprint = 0;
     args->block_size = 0;
     args->paths = NULL;
     args->path_count = 0;
@@ -59,7 +60,7 @@ void parse_args(int argc, char *argv[], Args *args) {
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "AialtrucUfhXvRFpI:BhHLZdgonCx1msQVk", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "AialtrucUfhXvRFpI:BhHLZdgonCx1msbQVk", long_options, NULL)) != -1) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
@@ -160,6 +161,9 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 'n':
             args->numeric_ids = 1;
             break;
+        case 'b':
+            args->escape_nonprint = 1;
+            break;
         case 'Q':
             args->quote_names = 1;
             break;
@@ -189,7 +193,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them or -H for command line arguments only. Context display with -Z is supported only on systems with SELinux.\n");
             exit(0);
             break;
@@ -198,7 +202,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -43,6 +43,7 @@ vls - colorized ls replacement
 - `-x` List entries across columns instead of vertically.
 - `-m` List entries separated by ", " wrapping lines to terminal width.
 - `-Q`, `--quote-name` Quote file names with double quotes, escaping internal quotes and backslashes.
+- `-b` Output backslash escapes for non-printable characters.
 - `-1` List one entry per line.
 - `--color=WHEN` Control colorization. WHEN is `auto`, `always` or `never`.
 - `--help` Display a brief usage message and exit.
@@ -59,6 +60,7 @@ vls -al
 vls -tR /etc
 vls --color=never
 vls -I '*.o'
+vls -b
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- add `escape_nonprint` to `Args` and parse `-b`
- allow quoting/escaping with `print_quoted`
- handle new argument in `list_directory`
- document the new flag in README, vlsdoc, and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68540817b15c8324b977fdd74e428e56