### PR TITLE
Add --hide pattern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A minimal, colorized replacement for `ls`.
 - Supports long listings and various sorting modes (time, size, extension, version)
 - Recursive listing and directory-first ordering
 - Pattern ignoring and indicator characters ("/", "*", "@"); use `--file-type` for directory markers only
+- Hide entries matching glob patterns with `--hide=PATTERN`
 - Optional dereferencing of command line symlinks (`-H`)
 - Optional display of SELinux contexts (`-Z`, Linux only)
 - Options for quoting names, human readable sizes, column layout (`-C`/`-x`) and comma-separated output (`-m`)

--- a/include/args.h
+++ b/include/args.h
@@ -41,6 +41,8 @@ typedef struct {
     int ignore_backups;
     const char **ignore_patterns;
     size_t ignore_count;
+    const char **hide_patterns;
+    size_t hide_count;
     int columns;
     int across_columns;
     int one_per_line;

--- a/include/list.h
+++ b/include/list.h
@@ -3,6 +3,6 @@
 
 #include "args.h"
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int file_type_only, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, int escape_nonprint, const char *time_style, unsigned block_size);
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int file_type_only, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, const char **hide_patterns, size_t hide_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, int escape_nonprint, const char *time_style, unsigned block_size);
 
 #endif // LIST_H

--- a/man/vls.1
+++ b/man/vls.1
@@ -132,6 +132,9 @@ Do not list files ending with '~'.
 .BR -I " PATTERN" , --ignore=PATTERN
 Do not list entries matching the shell PATTERN. May be repeated.
 .TP
+.B --hide=PATTERN
+Hide entries matching PATTERN unless -a or -A is used. May be repeated.
+.TP
 .BR -C
 List entries vertically in columns (default for terminals).
 .TP

--- a/src/args.c
+++ b/src/args.c
@@ -36,6 +36,8 @@ void parse_args(int argc, char *argv[], Args *args) {
     args->ignore_backups = 0;
     args->ignore_patterns = NULL;
     args->ignore_count = 0;
+    args->hide_patterns = NULL;
+    args->hide_count = 0;
     args->columns = isatty(STDOUT_FILENO);
     args->across_columns = 0;
     args->one_per_line = 0;
@@ -58,6 +60,7 @@ void parse_args(int argc, char *argv[], Args *args) {
         {"time-style", required_argument, 0, 5},
         {"full-time", no_argument, 0, 6},
         {"file-type", no_argument, 0, 7},
+        {"hide", required_argument, 0, 8},
         {"quote-name", no_argument, 0, 'Q'},
         {"help", no_argument, 0, 1},
         {"version", no_argument, 0, 'V'},
@@ -194,6 +197,15 @@ void parse_args(int argc, char *argv[], Args *args) {
         case 7:
             args->file_type_only = 1;
             break;
+        case 8:
+            args->hide_patterns = realloc(args->hide_patterns,
+                                          (args->hide_count + 1) * sizeof(char *));
+            if (!args->hide_patterns) {
+                perror("realloc");
+                exit(1);
+            }
+            args->hide_patterns[args->hide_count++] = optarg;
+            break;
         case 2:
             if (strcmp(optarg, "always") == 0)
                 args->color_mode = COLOR_ALWAYS;
@@ -207,7 +219,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             }
             break;
         case 1:
-            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--time-style=FMT] [--full-time] [--file-type] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            printf("Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--time-style=FMT] [--full-time] [--file-type] [--almost-all] [--ignore=PAT] [--hide=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             printf("Default is to display information about symbolic links. Use -L to follow them or -H for command line arguments only. Context display with -Z is supported only on systems with SELinux.\n");
             exit(0);
             break;
@@ -216,7 +228,7 @@ void parse_args(int argc, char *argv[], Args *args) {
             exit(0);
             break;
         default:
-            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--time-style=FMT] [--full-time] [--file-type] [--almost-all] [--ignore=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
+            fprintf(stderr, "Usage: %s [-a] [-A] [-l] [-i] [-t] [-u] [-c] [-S] [-X] [-v] [-f] [-U] [-r] [-R] [-d] [-p] [-I PAT] [-B] [-L] [-H] [-Z] [-F] [-C] [-x] [-m] [-1] [-h] [-n] [-g] [-o] [-s] [-k] [-b] [-Q] [-V] [--color=WHEN] [--block-size=SIZE] [--group-directories-first] [--time-style=FMT] [--full-time] [--file-type] [--almost-all] [--ignore=PAT] [--hide=PAT] [--quote-name] [--help] [--version] [path]\n", argv[0]);
             exit(1);
         }
     }

--- a/src/list.c
+++ b/src/list.c
@@ -189,7 +189,7 @@ static void print_quoted(const char *s, int quote, int escape_nonprint) {
         putchar('"');
 }
 
-void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int file_type_only, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, int escape_nonprint, const char *time_style, unsigned block_size) {
+void list_directory(const char *path, ColorMode color_mode, int show_hidden, int almost_all, int long_format, int show_inode, int sort_time, int sort_atime, int sort_ctime, int sort_size, int sort_extension, int sort_version, int unsorted, int reverse, int dirs_first, int recursive, int classify, int slash_dirs, int file_type_only, int human_readable, int numeric_ids, int hide_owner, int hide_group, int show_context, int follow_links, int list_dirs_only, int ignore_backups, const char **ignore_patterns, size_t ignore_count, const char **hide_patterns, size_t hide_count, int columns, int across_columns, int one_per_line, int comma_separated, int show_blocks, int quote_names, int escape_nonprint, const char *time_style, unsigned block_size) {
     int use_color = 0;
     if (color_mode == COLOR_ALWAYS)
         use_color = 1;
@@ -341,6 +341,14 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             continue;
         if (almost_all && (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0))
             continue;
+        if (hide_patterns && !show_hidden && !almost_all) {
+            int hide = 0;
+            for (size_t i = 0; i < hide_count && !hide; i++)
+                if (fnmatch(hide_patterns[i], entry->d_name, 0) == 0)
+                    hide = 1;
+            if (hide)
+                continue;
+        }
         if (ignore_backups) {
             size_t len = strlen(entry->d_name);
             if (len > 0 && entry->d_name[len - 1] == '~')
@@ -794,7 +802,7 @@ void list_directory(const char *path, ColorMode color_mode, int show_hidden, int
             char fullpath[PATH_MAX];
             snprintf(fullpath, sizeof(fullpath), "%s/%s", path, ent->name);
             printf("\n");
-            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_ctime, sort_size, sort_extension, sort_version, unsorted, reverse, dirs_first, recursive, classify, slash_dirs, file_type_only, human_readable, numeric_ids, hide_owner, hide_group, show_context, follow_links, list_dirs_only, ignore_backups, ignore_patterns, ignore_count, columns, across_columns, one_per_line, comma_separated, show_blocks, quote_names, escape_nonprint, time_style, block_size);
+            list_directory(fullpath, color_mode, show_hidden, almost_all, long_format, show_inode, sort_time, sort_atime, sort_ctime, sort_size, sort_extension, sort_version, unsorted, reverse, dirs_first, recursive, classify, slash_dirs, file_type_only, human_readable, numeric_ids, hide_owner, hide_group, show_context, follow_links, list_dirs_only, ignore_backups, ignore_patterns, ignore_count, hide_patterns, hide_count, columns, across_columns, one_per_line, comma_separated, show_blocks, quote_names, escape_nonprint, time_style, block_size);
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -53,8 +53,9 @@ int main(int argc, char *argv[]) {
                               args.classify, args.slash_dirs, args.file_type_only, args.human_readable,
                               args.numeric_ids, args.hide_owner, args.hide_group,
                               args.show_context, 1, 1, args.ignore_backups,
-                                args.ignore_patterns, args.ignore_count, args.columns,
-                                args.across_columns, args.one_per_line, args.comma_separated,
+                                args.ignore_patterns, args.ignore_count,
+                                args.hide_patterns, args.hide_count,
+                                args.columns, args.across_columns, args.one_per_line, args.comma_separated,
                                 args.show_blocks, args.quote_names, args.escape_nonprint, args.time_style, args.block_size);
                 if (i < args.path_count - 1)
                     printf("\n");
@@ -69,8 +70,9 @@ int main(int argc, char *argv[]) {
                       args.classify, args.slash_dirs, args.file_type_only, args.human_readable,
                       args.numeric_ids, args.hide_owner, args.hide_group,
                       args.show_context, args.follow_links, args.list_dirs_only, args.ignore_backups,
-                        args.ignore_patterns, args.ignore_count, args.columns,
-                        args.across_columns, args.one_per_line, args.comma_separated,
+                        args.ignore_patterns, args.ignore_count,
+                        args.hide_patterns, args.hide_count,
+                        args.columns, args.across_columns, args.one_per_line, args.comma_separated,
                         args.show_blocks, args.quote_names, args.escape_nonprint, args.time_style, args.block_size);
         if (i < args.path_count - 1)
             printf("\n");

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -42,6 +42,7 @@ vls - colorized ls replacement
 - `-o` Omit the group column in long format output.
 - `-B`, `--ignore-backups` Do not list files ending with '~'.
 - `-I PATTERN`, `--ignore=PATTERN` Do not list entries matching the shell PATTERN. May be repeated.
+- `--hide=PATTERN` Hide entries matching PATTERN unless `-a` or `-A` is used. May be repeated.
 - `-C` List entries vertically in columns (default for terminals).
 - `-x` List entries across columns instead of vertically.
 - `-m` List entries separated by ", " wrapping lines to terminal width.
@@ -63,6 +64,7 @@ vls -al
 vls -tR /etc
 vls --color=never
 vls -I '*.o'
+vls --hide='*.tmp'
 vls -b
 ```
 


### PR DESCRIPTION
## Summary
- add `hide_patterns` storage in `Args`
- parse `--hide=PATTERN` option
- filter hidden patterns early in directory traversal
- pass new arguments through list_directory
- document new feature in README, vlsdoc, and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68540f78f14c8324a71444b8730b7f18