### PR TITLE
Fix -A to show dot files and update docs

### DIFF
--- a/man/vls.1
+++ b/man/vls.1
@@ -28,7 +28,7 @@ option prints SELinux contexts when available and is only meaningful on Linux.
 Include directory entries whose names begin with a dot (.).
 .TP
 .BR -A , --almost-all
-List all entries except "." and "..".
+Show all dot files except "." and "..".
 .TP
 .BR -l
 Use a long listing format.

--- a/src/args.c
+++ b/src/args.c
@@ -90,6 +90,7 @@ void parse_args(int argc, char *argv[], Args *args) {
         switch (opt) {
         case 'A':
             args->almost_all = 1;
+            args->show_hidden = 1;
             break;
         case 'a':
             args->show_hidden = 1;

--- a/src/list.c
+++ b/src/list.c
@@ -419,7 +419,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
     }
 
     while ((entry = readdir(dir)) != NULL) {
-        if (!show_hidden && entry->d_name[0] == '.')
+        if (!show_hidden && !almost_all && entry->d_name[0] == '.')
             continue;
         if (almost_all && (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0))
             continue;

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -11,7 +11,7 @@ vls - colorized ls replacement
 
 ## Options
 - `-a` Include directory entries whose names begin with a dot (.).
-- `-A`, `--almost-all` List all entries except `.` and `..`.
+- `-A`, `--almost-all` Show all dot files except `.` and `..`.
 - `-l` Use a long listing format.
 - `-i` Print the inode number of each file.
 - `-t` Sort by modification time, newest first.


### PR DESCRIPTION
## Summary
- set `show_hidden` when parsing `-A`
- tweak directory filter logic
- document that `-A` shows dot files except `.` and `..`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68543eb061508324b297f5b41a2241d6