### PR TITLE
Fix link count printing

### DIFF
--- a/man/vls.1
+++ b/man/vls.1
@@ -228,3 +228,9 @@ Append indicator characters to entries
 Output OSC 8 hyperlinks for all file names
 .SH SEE ALSO
 .BR ls (1)
+.SH NOTES
+Earlier versions printed a constant hard link count of 1 when
+listing a single directory with
+.B -l
+. The count now reflects the actual
+number of hard links.

--- a/src/list.c
+++ b/src/list.c
@@ -291,6 +291,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
 
         unsigned long single_blocks = (unsigned long)((st.st_blocks * 512 + block_size - 1) / block_size);
         size_t single_w = num_digits(single_blocks);
+        size_t link_w = num_digits(st.st_nlink);
 
         if (long_format) {
             char size_buf[16];
@@ -351,7 +352,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
                 printf("%*lu ", (int)single_w, single_blocks);
             if (show_inode)
                 printf("%10llu ", (unsigned long long)st.st_ino);
-            printf("%s 1 ", perms);
+            printf("%s %*lu ", perms, (int)link_w, (unsigned long)st.st_nlink);
             if (!hide_owner)
                 printf("%-*s ", (int)strlen(owner_buf), owner_buf);
             if (!hide_group)

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -86,3 +86,8 @@ vls --hyperlink=always
 
 ## See Also
 `ls(1)`
+
+## Notes
+Earlier versions always displayed `1` as the link count when listing a
+single directory with `-l`. The count now shows the actual number of
+hard links.


### PR DESCRIPTION
## Summary
- show actual hard link count when listing a single directory
- align link count width with other columns
- document the fix in documentation and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68543f5a62308324b322bf9ec6421671