### PR TITLE
Guard SELinux header detection

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -13,9 +13,13 @@
 #include <time.h>
 #include <fnmatch.h>
 #include <stdbool.h>
-#if __has_include(<selinux/selinux.h>)
-# include <selinux/selinux.h>
-# define HAVE_SELINUX 1
+#ifdef __has_include
+# if __has_include(<selinux/selinux.h>)
+#  include <selinux/selinux.h>
+#  define HAVE_SELINUX 1
+# else
+#  define HAVE_SELINUX 0
+# endif
 #else
 # define HAVE_SELINUX 0
 #endif


### PR DESCRIPTION
## Summary
- detect `<selinux/selinux.h>` only when `__has_include` is available
- provide a fallback definition of `HAVE_SELINUX`
- verify build using GCC and TinyCC

## Testing
- `make`
- `make CC=tcc`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68545c79e0148324b58d4ddead198a73