### PR TITLE
Add SELinux detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC ?= cc
 CFLAGS ?= -Wall -Wextra -std=c99 -Iinclude
+LDFLAGS ?=
 
 PREFIX ?= /usr/local
 DESTDIR ?=
@@ -13,13 +14,20 @@ else ifeq ($(UNAME_S),Linux)
     PLATFORM_CFLAGS = -D_GNU_SOURCE
 endif
 CFLAGS += $(PLATFORM_CFLAGS)
+SELINUX_TEST := $(shell mkdir -p build; echo 'int main(void){return 0;}' > build/selinux.c; if $(CC) $(CFLAGS) build/selinux.c -o build/selinux_test -lselinux >/dev/null 2>&1; then echo 1; else echo 0; fi; rm -f build/selinux.c build/selinux_test)
+ifeq ($(SELINUX_TEST),1)
+    CFLAGS += -DHAVE_SELINUX=1
+    LDFLAGS += -lselinux
+else
+    CFLAGS += -DHAVE_SELINUX=0
+endif
 OBJS = build/main.o build/list.o build/color.o build/args.o build/util.o build/quote.o
 DEPS = include/list.h include/color.h include/args.h include/util.h include/quote.h
 
 all: build/vls
 
 build/vls: $(OBJS) | build
-	$(CC) $(CFLAGS) $(OBJS) -o build/vls
+	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) -o build/vls
 
 build/main.o: src/main.c $(DEPS) | build
 	$(CC) $(CFLAGS) -c src/main.c -o build/main.o

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A minimal, colorized replacement for `ls`.
   `--file-type` for directory markers only
 - Hide entries matching glob patterns with `--hide=PATTERN`
 - Optional dereferencing of command line symlinks (`-H`)
-- Optional display of SELinux contexts (`-Z`, Linux only)
+- Optional display of SELinux contexts (`-Z`, Linux only, requires libselinux)
 - Quoting styles with `--quoting-style=STYLE` (`literal`, `c`, `escape`),
   with `-Q` and `-b` as shortcuts
 - Print names literally with `-N`/`--literal`, overriding quoting and
@@ -34,6 +34,7 @@ at [man/vls.1](./man/vls.1).
 
 ## Building
 Run `make` to compile. Override `CFLAGS` or `PREFIX` as needed.
+SELinux support requires the libselinux development package to be installed.
 
 ## Installation
 Install with `sudo make install`. Use `PREFIX` to choose a different

--- a/src/list.c
+++ b/src/list.c
@@ -13,15 +13,21 @@
 #include <time.h>
 #include <fnmatch.h>
 #include <stdbool.h>
-#ifdef __has_include
-# if __has_include(<selinux/selinux.h>)
-#  include <selinux/selinux.h>
-#  define HAVE_SELINUX 1
-# else
-#  define HAVE_SELINUX 0
-# endif
-#else
+#ifndef HAVE_SELINUX
 # define HAVE_SELINUX 0
+#endif
+
+#if HAVE_SELINUX
+# ifdef __has_include
+#  if __has_include(<selinux/selinux.h>)
+#   include <selinux/selinux.h>
+#  else
+#   undef HAVE_SELINUX
+#   define HAVE_SELINUX 0
+#  endif
+# else
+#  include <selinux/selinux.h>
+# endif
 #endif
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
 # include <sys/param.h>


### PR DESCRIPTION
## Summary
- detect libselinux in Makefile and set `HAVE_SELINUX`
- link with `-lselinux` only when available
- guard SELinux includes with `HAVE_SELINUX`
- document the optional dependency in README

## Testing
- `make clean`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854656c967083248a4518b5916cbcf8