### PR TITLE
Clarify block-size argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A minimal, colorized replacement for `ls`.
 - Display control characters literally with `--show-control-chars`
 - Human readable sizes (`-h` uses powers of 1024, `--si` uses powers of
   1000), column layout (`-C`/`-x`) and comma-separated output (`-m`)
+- Override the block size used for `-s` with `--block-size=SIZE` where `SIZE`
+  is a number of bytes with no unit suffix; use `-k` for 1 KiB blocks
 - Set output width with `-w COLS` and tab size with `-T COLS`
 - Customizable timestamp format via `--time-style=FMT` and `--full-time`
 - Select which timestamp to show with `--time=WORD` (`mod`, `access`,

--- a/man/vls.1
+++ b/man/vls.1
@@ -121,7 +121,8 @@ appears before the listing showing the sum of blocks for the displayed files
 according to the current block size.
 .TP
 .BR --block-size=SIZE
-Override the default block size (512 or 1024 bytes).
+Override the default block size. SIZE is a number of bytes with no unit
+suffix.
 .TP
 .BR -k
 Use 1 KiB blocks for size calculations.

--- a/vlsdoc.md
+++ b/vlsdoc.md
@@ -39,7 +39,8 @@ vls - colorized ls replacement
 - `--file-type` Like `-p` but ignores other indicators unless `-F` is also given.
 - `--indicator-style=STYLE` Choose indicator style: `none`, `slash`, `file-type`, `classify`.
 - `-s` Display the number of blocks allocated to each file. When used with `-l` or `-s`, a line of the form `total <num>` appears before the listing showing the sum of blocks for the displayed files according to the current block size.
-- `--block-size=SIZE` Override the default block size (512 or 1024 bytes).
+- `--block-size=SIZE` Override the default block size. `SIZE` is a number of
+  bytes with no unit suffix.
 - `-k` Use 1 KiB blocks for size calculations.
 - `-h` With `-l`, print sizes in human readable format using powers of 1024.
 - `--si` Like `-h` but use powers of 1000.


### PR DESCRIPTION
## Summary
- document that `--block-size` takes a raw byte count

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685466ab754c8324831160d2350b1a04