### PR TITLE
Improve regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,21 +55,24 @@ test: build/vls
 	mkdir -p build/testdir
 	touch build/testdir/foo build/testdir/.bar
 	@set -e; \
-	./build/vls -A build/testdir > build/out_A.txt; \
-	test $$? -eq 0; \
+	./build/vls -A build/testdir > build/out_A.txt; rc=$$?; \
+	echo $$rc > build/rc_A.txt; test $$rc -eq 0; \
 	grep -q '.bar' build/out_A.txt; \
-	./build/vls -d build/testdir > build/out_d.txt; \
-	test $$? -eq 0; \
+	./build/vls -d build/testdir > build/out_d.txt; rc=$$?; \
+	echo $$rc > build/rc_d.txt; test $$rc -eq 0; \
 	grep -q 'testdir' build/out_d.txt; \
-	./build/vls -C build/testdir > build/out_C.txt; \
-	test $$? -eq 0; \
+	./build/vls -C build/testdir > build/out_C.txt; rc=$$?; \
+	echo $$rc > build/rc_C.txt; test $$rc -eq 0; \
 	test -s build/out_C.txt; \
-	./build/vls -m build/testdir > build/out_m.txt; \
-	test $$? -eq 0; \
+	./build/vls -m build/testdir > build/out_m.txt; rc=$$?; \
+	echo $$rc > build/rc_m.txt; test $$rc -eq 0; \
 	test -s build/out_m.txt; \
-	./build/vls --color=always build/testdir > build/out_color.txt; \
-	test $$? -eq 0; \
-	grep -P -q '\x1b\[' build/out_color.txt; \
+	./build/vls --color=always build/testdir > build/out_color_on.txt; rc=$$?; \
+	echo $$rc > build/rc_color_on.txt; test $$rc -eq 0; \
+	grep -P -q '\x1b\[' build/out_color_on.txt; \
+	./build/vls --color=never build/testdir > build/out_color_off.txt; rc=$$?; \
+	echo $$rc > build/rc_color_off.txt; test $$rc -eq 0; \
+	! grep -P -q '\x1b\[' build/out_color_off.txt; \
 	rm -r build/testdir; \
 	echo "Tests completed"
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ destination.
 ## Testing
 Run `make test` to compile `vls` and execute a small regression suite.
 The tests create a temporary directory under `build/` and exercise
-options such as `-A`, `-d`, `-C`, `-m` and colorized output.  Output is
-captured to files in `build/` and exit codes are checked.  A message is
-printed once all tests pass.
+options such as `-A`, `-d`, `-C`, `-m` and both `--color=always` and
+`--color=never`. Output and the exit status for each invocation are
+saved in `build/` for inspection. The script verifies that every command
+succeeds and prints expected data. A message is printed once all tests
+pass.
 
 ## License
 Distributed under the GNU General Public License version 3.


### PR DESCRIPTION
## Summary
- broaden `make test` coverage
- log exit status for each test
- document running tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68547364b4008324951984f25f69d4d9