### PR TITLE
Improve error messages

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -6,6 +6,7 @@
 #include <strings.h>
 #include <limits.h>
 #include <unistd.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <pwd.h>
@@ -244,7 +245,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
         struct stat st;
         int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
         if (stat_fn(path, &st) == -1) {
-            perror("stat");
+            fprintf(stderr, "stat: %s: %s\n", path, strerror(errno));
             free(pwbuf);
             free(grbuf);
             return;
@@ -407,7 +408,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
 
     DIR *dir = opendir(path);
     if (!dir) {
-        perror("opendir");
+        fprintf(stderr, "opendir: %s: %s\n", path, strerror(errno));
         free(pwbuf);
         free(grbuf);
         return;
@@ -478,7 +479,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
         }
         int (*stat_fn)(const char *, struct stat *) = follow_links ? stat : lstat;
         if (stat_fn(fullpath, &entries[count].st) == -1) {
-            perror("stat");
+            fprintf(stderr, "stat: %s: %s\n", fullpath, strerror(errno));
             free(fullpath);
             free(entries[count].name);
             continue;

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,8 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
 static int hyperlink_enabled(HyperlinkMode mode) {
     return mode == HYPERLINK_ALWAYS || (mode == HYPERLINK_AUTO && isatty(STDOUT_FILENO));
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
         if (args.deref_cmdline) {
             struct stat st;
             if (stat(path, &st) == -1) {
-                perror("stat");
+                fprintf(stderr, "stat: %s: %s\n", path, strerror(errno));
                 continue;
             }
             if (args.list_dirs_only || !S_ISDIR(st.st_mode)) {


### PR DESCRIPTION
## Summary
- include `errno.h` and `string.h` where needed
- print path information when `stat` or `opendir` fails

## Testing
- `make clean test`

------
https://chatgpt.com/codex/tasks/task_e_6854763ff36c8324977746826431e91b