### PR TITLE
Handle empty directories gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build:
 
 test: build/vls
 	@echo "Running tests..."
-	mkdir -p build/testdir
+	mkdir -p build/testdir build/emptydir
 	touch build/testdir/foo build/testdir/.bar
 	@set -e; \
 	./build/vls -A build/testdir > build/out_A.txt; rc=$$?; \
@@ -73,7 +73,10 @@ test: build/vls
 	./build/vls --color=never build/testdir > build/out_color_off.txt; rc=$$?; \
 	echo $$rc > build/rc_color_off.txt; test $$rc -eq 0; \
 	! grep -P -q '\x1b\[' build/out_color_off.txt; \
-	rm -r build/testdir; \
+	./build/vls -C build/emptydir > build/out_empty.txt; rc=$$?; \
+	echo $$rc > build/rc_empty.txt; test $$rc -eq 0; \
+grep -q '^$$' build/out_empty.txt; \
+	rm -r build/testdir build/emptydir; \
 	echo "Tests completed"
 
 install: build/vls

--- a/src/list.c
+++ b/src/list.c
@@ -774,14 +774,17 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
             }
         }
     } else if (!long_format && columns && !one_per_line) {
-        int term_width = output_width;
-        size_t col_width = ((max_len + tabsize - 1) / tabsize) * tabsize + 2;
-        size_t cols = term_width / (int)col_width;
-        if (cols == 0)
-            cols = 1;
-        if (cols > count)
-            cols = count;
-        size_t rows = (count + cols - 1) / cols;
+        if (count == 0) {
+            putchar('\n');
+        } else {
+            int term_width = output_width;
+            size_t col_width = ((max_len + tabsize - 1) / tabsize) * tabsize + 2;
+            size_t cols = term_width / (int)col_width;
+            if (cols == 0)
+                cols = 1;
+            if (cols > count)
+                cols = count;
+            size_t rows = (count + cols - 1) / cols;
 
         if (across_columns) {
             for (size_t i = 0; i < count; i++) {
@@ -926,6 +929,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
                     }
                 }
             }
+        }
         }
     } else {
     for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary
- avoid division by zero when listing empty directories
- print a newline for empty listings
- add a regression test for empty directories

## Testing
- `make clean >/dev/null`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68547920f9bc8324a1964f1b2e5bd9f1