### PR TITLE
Remove PATH_MAX macros

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -4,7 +4,6 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <strings.h>
-#include <limits.h>
 #include <unistd.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -30,15 +29,6 @@
 # else
 #  include <selinux/selinux.h>
 # endif
-#endif
-#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
-# include <sys/param.h>
-# ifndef PATH_MAX
-#  define PATH_MAX MAXPATHLEN
-# endif
-#endif
-#ifndef PATH_MAX
-# define PATH_MAX 4096
 #endif
 #include "list.h"
 #include "color.h"


### PR DESCRIPTION
## Summary
- drop fallback definitions for `PATH_MAX`
- remove unused includes

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68549f8cebac8324bdaceb70bb58ad6c