### PR TITLE
Fix colored alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,14 @@ test: build/vls
         ./build/vls --color=never build/testdir > build/out_color_off.txt; rc=$$?; \
         echo $$rc > build/rc_color_off.txt; test $$rc -eq 0; \
         ! grep -P -q '\x1b\[' build/out_color_off.txt; \
+        ./build/vls -C --color=always build/testdir > build/out_color_cols.txt; rc=$$?; \
+        echo $$rc > build/rc_color_cols.txt; test $$rc -eq 0; \
+        sed -r 's/\x1b\[[0-9;]*m//g' build/out_color_cols.txt > build/out_color_cols_clean.txt; \
+        ./build/vls -C --color=never build/testdir > build/out_C_nocolor.txt; rc=$$?; \
+        echo $$rc > build/rc_C_nocolor.txt; test $$rc -eq 0; \
+        len_color=$(awk '{print length}' build/out_color_cols_clean.txt); \
+        len_nocolor=$(awk '{print length}' build/out_C_nocolor.txt); \
+        test $$len_color -ge $$len_nocolor; \
         ./build/vls -Q build/testdir > build/out_Q.txt; rc=$$?; \
         echo $$rc > build/rc_Q.txt; test $$rc -eq 0; \
         grep -q '"café"' build/out_Q.txt; \

--- a/src/list.c
+++ b/src/list.c
@@ -706,6 +706,16 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
         default:
             break;
         }
+        if (use_color) {
+            const char *pfx = "";
+            if (S_ISDIR(ent->st.st_mode))
+                pfx = color_dir();
+            else if (S_ISLNK(ent->st.st_mode))
+                pfx = color_link();
+            else if (ent->st.st_mode & S_IXUSR)
+                pfx = color_exec();
+            name_len += strlen(pfx) + strlen(color_reset());
+        }
         if (name_len > max_len)
             max_len = name_len;
     }
@@ -769,7 +779,7 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
             size_t len = strlen(block_buf) + strlen(inode_buf) +
                          (quote_names ? quoted_len(ent->name, escape_nonprint, hide_control) :
                           (escape_nonprint ? escaped_len(ent->name, hide_control) : strlen(ent->name))) +
-                         strlen(indicator);
+                         strlen(indicator) + strlen(prefix) + strlen(suffix);
             if (line_len && line_len + len > (size_t)term_width) {
                 putchar('\n');
                 line_len = 0;
@@ -872,7 +882,8 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
 
             size_t len = (quote_names ? quoted_len(ent->name, escape_nonprint, hide_control) :
                            (escape_nonprint ? escaped_len(ent->name, hide_control) : strlen(ent->name))) +
-                         strlen(indicator) + strlen(inode_buf) + strlen(block_buf);
+                         strlen(indicator) + strlen(inode_buf) + strlen(block_buf) +
+                         strlen(prefix) + strlen(suffix);
             if ((i % cols == cols - 1) || i == count - 1) {
                 putchar('\n');
             } else {
@@ -945,7 +956,8 @@ void list_directory(const char *path, ColorMode color_mode, HyperlinkMode hyperl
 
                     size_t len = (quote_names ? quoted_len(ent->name, escape_nonprint, hide_control) :
                                    (escape_nonprint ? escaped_len(ent->name, hide_control) : strlen(ent->name))) +
-                                 strlen(indicator) + strlen(inode_buf) + strlen(block_buf);
+                                 strlen(indicator) + strlen(inode_buf) + strlen(block_buf) +
+                                 strlen(prefix) + strlen(suffix);
                     if (c == cols - 1 || i + rows >= count) {
                         putchar('\n');
                     } else {


### PR DESCRIPTION
## Summary
- account for ANSI color escape sequences when computing field widths
- ensure colored column output is at least as wide as non-colored output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854a2c3660883249898c3f79ea3d892